### PR TITLE
fix: Use APT_INSTALL variable consistently

### DIFF
--- a/ml_in_a_box.sh
+++ b/ml_in_a_box.sh
@@ -146,8 +146,8 @@
     sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
     sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
     sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
-    sudo apt-get install libcudnn8=8.5.0.*-1+cuda11.7
-    sudo apt-get install libcudnn8-dev=8.5.0.*-1+cuda11.7
+    sudo $APT_INSTALL libcudnn8=8.5.0.*-1+cuda11.7
+    sudo $APT_INSTALL libcudnn8-dev=8.5.0.*-1+cuda11.7
 
 
 # ==================================================================


### PR DESCRIPTION
This was causing a script hang during template creation if the script was re-run.